### PR TITLE
Simplify limiting extensions.

### DIFF
--- a/src/thread.h
+++ b/src/thread.h
@@ -60,16 +60,11 @@ public:
   Pawns::Table pawnsTable;
   Material::Table materialTable;
   size_t pvIdx, pvLast;
-  RunningAverage doubleExtensionAverage[COLOR_NB];
   RunningAverage complexityAverage;
-  uint64_t nodesLastExplosive;
-  uint64_t nodesLastNormal;
   std::atomic<uint64_t> nodes, tbHits, bestMoveChanges;
-  Value bestValue;
   int selDepth, nmpMinPly;
   Color nmpColor;
-  ExplosionState state;
-  Value optimism[COLOR_NB];
+  Value bestValue, optimism[COLOR_NB];
 
   Position rootPos;
   StateInfo rootState;


### PR DESCRIPTION
Replace the current method for limiting extensions to avoid search getting stuck
with a much simpler method.

the test position in https://github.com/official-stockfish/Stockfish/commit/73018a03375b4b72ee482eb5a4a2152d7e4f0aac
can still be searched without stuck search.

fixes #3815 where the search now makes progress with rootDepth

shows robust behavior in a d10 search for 1M positions.

passed STC
https://tests.stockfishchess.org/tests/view/61e303e3babab931824dfb18
LLR: 2.94 (-2.94,2.94) <-2.25,0.25>
Total: 57568 W: 15449 L: 15327 D: 26792
Ptnml(0-2): 243, 6211, 15779, 6283, 268

passed LTC
https://tests.stockfishchess.org/tests/view/61e3586cbabab931824e091c
LLR: 2.96 (-2.94,2.94) <-2.25,0.25>
Total: 128200 W: 34632 L: 34613 D: 58955
Ptnml(0-2): 124, 12559, 38710, 12588, 119

closes https://github.com/official-stockfish/Stockfish/pull/3899

Bench: 4550528